### PR TITLE
Kilosort(2) firings.mda dtype increase

### DIFF
--- a/spikeforest/spikesorters/kilosort/p_kilosort.m
+++ b/spikeforest/spikesorters/kilosort/p_kilosort.m
@@ -36,7 +36,7 @@ function mr_out = export_ksort_(rez, firings_out_fname)
 mr_out = zeros(size(rez.st3,1), 3, 'double'); 
 mr_out(:,2) = rez.st3(:,1); %time
 mr_out(:,3) = rez.st3(:,2); %cluster
-writemda(mr_out', firings_out_fname, 'float32');
+writemda(mr_out', firings_out_fname, 'float64');
 end %func
 
 

--- a/spikeforest/spikesorters/kilosort2/p_kilosort2.m
+++ b/spikeforest/spikesorters/kilosort2/p_kilosort2.m
@@ -55,7 +55,7 @@ function mr_out = export_ksort_(rez, firings_out_fname)
 mr_out = zeros(size(rez.st3,1), 3, 'double'); 
 mr_out(:,2) = rez.st3(:,1); %time
 mr_out(:,3) = rez.st3(:,2); %cluster
-writemda(mr_out', firings_out_fname, 'float32');
+writemda(mr_out', firings_out_fname, 'float64');
 end %func
 
 


### PR DESCRIPTION
Without this loss of precision will lead to weird (and silent) bugs for longer recordings.

We could set the dtype dynamically but I don't think the `firings.mda` size is a big constraint.